### PR TITLE
change state参照からgetter参照に変更

### DIFF
--- a/pages/count.vue
+++ b/pages/count.vue
@@ -9,7 +9,7 @@
 export default {
   computed: {
     count() {
-      return this.$store.state.count.count
+      return this.$store.getters['count/getCount']
     }
   },
   methods: {

--- a/store/count.js
+++ b/store/count.js
@@ -2,6 +2,11 @@
 export const state = () => ({
   count: 0
 })
+export const getters = {
+  getCount: (state) => {
+    return state.count
+  },
+}
 
 // 状態を変更する処理は mutationとしてexportする
 export const mutations = {


### PR DESCRIPTION
Vuexで作成したcountアプリで、state参照からgetter参照に変更しました。
stateで直接参照すると値を変更するなど危険性もあるため、getterに変更しました。